### PR TITLE
Remove `modelFor` usage from json serializer.

### DIFF
--- a/packages/serializer/src/-private/embedded-records-mixin.js
+++ b/packages/serializer/src/-private/embedded-records-mixin.js
@@ -210,8 +210,7 @@ export default Mixin.create({
     let includeRecords = this.hasSerializeRecordsOption(attr);
     let embeddedSnapshot = snapshot.belongsTo(attr);
     if (includeIds) {
-      let schema = this.store.modelFor(snapshot.modelName);
-      let serializedKey = this._getMappedKey(relationship.key, schema);
+      let serializedKey = this._getMappedKey(relationship.key, snapshot.modelName);
       if (serializedKey === relationship.key && this.keyForRelationship) {
         serializedKey = this.keyForRelationship(relationship.key, relationship.kind, 'serialize');
       }
@@ -232,8 +231,7 @@ export default Mixin.create({
 
   _serializeEmbeddedBelongsTo(snapshot, json, relationship) {
     let embeddedSnapshot = snapshot.belongsTo(relationship.key);
-    let schema = this.store.modelFor(snapshot.modelName);
-    let serializedKey = this._getMappedKey(relationship.key, schema);
+    let serializedKey = this._getMappedKey(relationship.key, snapshot.modelName);
     if (serializedKey === relationship.key && this.keyForRelationship) {
       serializedKey = this.keyForRelationship(relationship.key, relationship.kind, 'serialize');
     }
@@ -396,8 +394,7 @@ export default Mixin.create({
     }
 
     if (this.hasSerializeIdsOption(attr)) {
-      let schema = this.store.modelFor(snapshot.modelName);
-      let serializedKey = this._getMappedKey(relationship.key, schema);
+      let serializedKey = this._getMappedKey(relationship.key, snapshot.modelName);
       if (serializedKey === relationship.key && this.keyForRelationship) {
         serializedKey = this.keyForRelationship(relationship.key, relationship.kind, 'serialize');
       }
@@ -434,8 +431,7 @@ export default Mixin.create({
   },
 
   _serializeEmbeddedHasMany(snapshot, json, relationship) {
-    let schema = this.store.modelFor(snapshot.modelName);
-    let serializedKey = this._getMappedKey(relationship.key, schema);
+    let serializedKey = this._getMappedKey(relationship.key, snapshot.modelName);
     if (serializedKey === relationship.key && this.keyForRelationship) {
       serializedKey = this.keyForRelationship(relationship.key, relationship.kind, 'serialize');
     }

--- a/packages/serializer/src/json-api.js
+++ b/packages/serializer/src/json-api.js
@@ -655,8 +655,7 @@ const JSONAPISerializer = JSONSerializer.extend({
         value = transform.serialize(value, attribute.options);
       }
 
-      let schema = this.store.modelFor(snapshot.modelName);
-      let payloadKey = this._getMappedKey(key, schema);
+      let payloadKey = this._getMappedKey(key, snapshot.modelName);
 
       if (payloadKey === key) {
         payloadKey = this.keyForAttribute(key, 'serialize');
@@ -676,8 +675,7 @@ const JSONAPISerializer = JSONSerializer.extend({
       if (belongsTo === null || belongsToIsNotNew) {
         json.relationships = json.relationships || {};
 
-        let schema = this.store.modelFor(snapshot.modelName);
-        let payloadKey = this._getMappedKey(key, schema);
+        let payloadKey = this._getMappedKey(key, snapshot.modelName);
         if (payloadKey === key) {
           payloadKey = this.keyForRelationship(key, 'belongsTo', 'serialize');
         }
@@ -705,8 +703,7 @@ const JSONAPISerializer = JSONSerializer.extend({
       if (hasMany !== undefined) {
         json.relationships = json.relationships || {};
 
-        let schema = this.store.modelFor(snapshot.modelName);
-        let payloadKey = this._getMappedKey(key, schema);
+        let payloadKey = this._getMappedKey(key, snapshot.modelName);
         if (payloadKey === key && this.keyForRelationship) {
           payloadKey = this.keyForRelationship(key, 'hasMany', 'serialize');
         }

--- a/packages/serializer/src/rest.js
+++ b/packages/serializer/src/rest.js
@@ -408,7 +408,7 @@ const RESTSerializer = JSONSerializer.extend({
         continue;
       }
       var type = store.modelFor(modelName);
-      var typeSerializer = store.serializerFor(type.modelName);
+      var typeSerializer = store.serializerFor(modelName);
 
       makeArray(payload[prop]).forEach((hash) => {
         let { data, included } = typeSerializer.normalize(type, hash, prop);


### PR DESCRIPTION
Replace `modelFor` by using schema definition service.

## Description

Use preferred method of querying attributes and relationships in legacy json serializer. 


